### PR TITLE
Use hash of command string as resource ID

### DIFF
--- a/command/resource_command.go
+++ b/command/resource_command.go
@@ -3,6 +3,8 @@ package command
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os/exec"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -69,7 +71,9 @@ func resourceCommandCreate(ctx context.Context, d *schema.ResourceData, m interf
 		})
 	}
 
-	d.SetId(cmd.String())
+	id := sha256.Sum256([]byte(cmd.String()))
+	d.SetId(hex.EncodeToString(id[:]))
+
 	d.Set("stdout", stdout.String())
 	d.Set("stderr", stderr.String())
 


### PR DESCRIPTION
Previously we used raw `cmd.String()`, but this is output to the console when the resource is destroyed, potentially leaking sensitive values.